### PR TITLE
Update domain to api.searchad.naver.com

### DIFF
--- a/lib/naver/searchad/api/ad-keyword/service.rb
+++ b/lib/naver/searchad/api/ad-keyword/service.rb
@@ -7,7 +7,7 @@ module Naver
         class Service < Naver::Searchad::Api::Core::BaseService
 
           def initialize
-            super('https://api.naver.com/', 'ncc/')
+            super('https://api.searchad.naver.com/', 'ncc/')
           end
 
           def list_ad_keywords_by_ids(ad_keyword_ids, options: nil, &block)

--- a/lib/naver/searchad/api/ad/service.rb
+++ b/lib/naver/searchad/api/ad/service.rb
@@ -7,7 +7,7 @@ module Naver
         class Service < Naver::Searchad::Api::Core::BaseService
 
           def initialize
-            super('https://api.naver.com/', 'ncc/')
+            super('https://api.searchad.naver.com/', 'ncc/')
           end
 
           def list_ads(ad_ids, options: nil, &block)

--- a/lib/naver/searchad/api/adgroup/service.rb
+++ b/lib/naver/searchad/api/adgroup/service.rb
@@ -7,7 +7,7 @@ module Naver
         class Service < Naver::Searchad::Api::Core::BaseService
 
           def initialize
-            super('https://api.naver.com/', 'ncc/')
+            super('https://api.searchad.naver.com/', 'ncc/')
           end
 
           def list_adgroups(options: nil, &block)

--- a/lib/naver/searchad/api/bizmoney/service.rb
+++ b/lib/naver/searchad/api/bizmoney/service.rb
@@ -7,7 +7,7 @@ module Naver
         class Service < Naver::Searchad::Api::Core::BaseService
 
           def initialize
-            super('https://api.naver.com/', 'billing/')
+            super('https://api.searchad.naver.com/', 'billing/')
           end
 
           def get_bizmoney(options: nil, &block)

--- a/lib/naver/searchad/api/business-channel/service.rb
+++ b/lib/naver/searchad/api/business-channel/service.rb
@@ -7,7 +7,7 @@ module Naver
         class Service < Naver::Searchad::Api::Core::BaseService
 
           def initialize
-            super('https://api.naver.com/', 'ncc/')
+            super('https://api.searchad.naver.com/', 'ncc/')
           end
 
           def list_channels(options: nil, &block)

--- a/lib/naver/searchad/api/campaign/service.rb
+++ b/lib/naver/searchad/api/campaign/service.rb
@@ -7,7 +7,7 @@ module Naver
         class Service < Naver::Searchad::Api::Core::BaseService
 
           def initialize
-            super('https://api.naver.com/', 'ncc/')
+            super('https://api.searchad.naver.com/', 'ncc/')
           end
 
           def list_campaigns(options: nil, &block)

--- a/lib/naver/searchad/api/label/service.rb
+++ b/lib/naver/searchad/api/label/service.rb
@@ -7,7 +7,7 @@ module Naver
         class Service < Naver::Searchad::Api::Core::BaseService
 
           def initialize
-            super('https://api.naver.com/', 'ncc/')
+            super('https://api.searchad.naver.com/', 'ncc/')
           end
 
           def list_labels(options: nil, &block)

--- a/lib/naver/searchad/api/related-keyword-stat/service.rb
+++ b/lib/naver/searchad/api/related-keyword-stat/service.rb
@@ -7,7 +7,7 @@ module Naver
         class Service < Naver::Searchad::Api::Core::BaseService
 
           def initialize
-            super('https://api.naver.com/', '')
+            super('https://api.searchad.naver.com/', '')
           end
 
           def list_stats(options: nil, &block)

--- a/lib/naver/searchad/api/stat-report/service.rb
+++ b/lib/naver/searchad/api/stat-report/service.rb
@@ -8,7 +8,7 @@ module Naver
         class Service < Naver::Searchad::Api::Core::BaseService
 
           def initialize
-            super('https://api.naver.com/', '')
+            super('https://api.searchad.naver.com/', '')
           end
 
           def download_report(download_url, file_path, options: {}, &block)

--- a/lib/naver/searchad/api/stat/service.rb
+++ b/lib/naver/searchad/api/stat/service.rb
@@ -7,7 +7,7 @@ module Naver
         class Service < Naver::Searchad::Api::Core::BaseService
 
           def initialize
-            super('https://api.naver.com/', '')
+            super('https://api.searchad.naver.com/', '')
           end
 
           def get_stat_by_id(id,

--- a/lib/naver/searchad/api/version.rb
+++ b/lib/naver/searchad/api/version.rb
@@ -1,7 +1,7 @@
 module Naver
   module Searchad
     module Api
-      VERSION = '1.0.0'
+      VERSION = '1.0.1'
 
       OS_VERSION = begin
         if RUBY_PLATFORM =~ /mswin|win32|mingw|bccwin|cygwin/

--- a/naver-searchad-api.gemspec
+++ b/naver-searchad-api.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'httpclient', '>= 2.8.1', '< 3.0'
   spec.add_runtime_dependency 'addressable', '~> 2.5'
 
-  spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'simplecov', '~> 0.14'

--- a/spec/naver/searchad/api/ad-keyword/service_spec.rb
+++ b/spec/naver/searchad/api/ad-keyword/service_spec.rb
@@ -12,7 +12,7 @@ describe AdKeyword::Service do
     context 'when requesting more than one' do
       let(:ids) {['nkw-a001-01-000000723631063', 'nkw-a001-01-000000723631064']}
       before(:each) do
-        stub_request(:get, 'https://api.naver.com/ncc/keywords?ids=nkw-a001-01-000000723631063,nkw-a001-01-000000723631064').
+        stub_request(:get, 'https://api.searchad.naver.com/ncc/keywords?ids=nkw-a001-01-000000723631063,nkw-a001-01-000000723631064').
           to_return(
             status: 200,
             headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -99,7 +99,7 @@ JSON
     context 'when all ok' do
       let(:adgroup_id) { 'grp-a001-01-000000003865468' }
       before(:each) do
-        stub_request(:get, 'https://api.naver.com/ncc/keywords?nccAdgroupId=grp-a001-01-000000003865468').
+        stub_request(:get, 'https://api.searchad.naver.com/ncc/keywords?nccAdgroupId=grp-a001-01-000000003865468').
           to_return(
             status: 200,
             headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -186,7 +186,7 @@ JSON
     context 'when all ok' do
       let(:label_id) { 'label_id' }
       before(:each) do
-        stub_request(:get, 'https://api.naver.com/ncc/keywords?nccLabelId=label_id').
+        stub_request(:get, 'https://api.searchad.naver.com/ncc/keywords?nccLabelId=label_id').
           to_return(
             status: 200,
             headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -273,7 +273,7 @@ JSON
     context 'when all ok' do
       let(:ad_keyword_id) { 'nkw-a001-01-000000723631063' }
       before(:each) do
-        stub_request(:get, 'https://api.naver.com/ncc/keywords/nkw-a001-01-000000723631063').
+        stub_request(:get, 'https://api.searchad.naver.com/ncc/keywords/nkw-a001-01-000000723631063').
           to_return(
             status: 200,
             headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -328,7 +328,7 @@ JSON
     context 'when creating an ad keyword with only required attribute' do
       let(:ad_keyword) { { 'keyword' => 'test-keyword-02' } }
       before(:each) do
-        stub_request(:post, 'https://api.naver.com/ncc/keywords?nccAdgroupId=grp-a001-01-000000003865468').
+        stub_request(:post, 'https://api.searchad.naver.com/ncc/keywords?nccAdgroupId=grp-a001-01-000000003865468').
           to_return(
             status: 200,
             headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -404,7 +404,7 @@ JSON
         }
       }
       before(:each) do
-        stub_request(:post, 'https://api.naver.com/ncc/keywords?nccAdgroupId=grp-a001-01-000000003865468').
+        stub_request(:post, 'https://api.searchad.naver.com/ncc/keywords?nccAdgroupId=grp-a001-01-000000003865468').
           to_return(
             status: 200,
             headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -484,7 +484,7 @@ JSON
         ]
       }
       before(:each) do
-        stub_request(:post, 'https://api.naver.com/ncc/keywords?nccAdgroupId=grp-a001-01-000000003865468').
+        stub_request(:post, 'https://api.searchad.naver.com/ncc/keywords?nccAdgroupId=grp-a001-01-000000003865468').
           to_return(
             status: 200,
             headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -568,7 +568,7 @@ JSON
       let(:ad_keyword) { { 'keyword' => 'existing-keyword' } }
 
       before(:each) do
-        stub_request(:post, 'https://api.naver.com/ncc/keywords?nccAdgroupId=grp-a001-01-000000003865468').
+        stub_request(:post, 'https://api.searchad.naver.com/ncc/keywords?nccAdgroupId=grp-a001-01-000000003865468').
           to_return(
             status: 200,
             headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -611,7 +611,7 @@ JSON
           }
         }
         before(:each) do
-          stub_request(:put, 'https://api.naver.com/ncc/keywords/nkw-a001-01-000000725744770?fields=userLock').
+          stub_request(:put, 'https://api.searchad.naver.com/ncc/keywords/nkw-a001-01-000000725744770?fields=userLock').
             to_return(
               status: 200,
               headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -644,7 +644,7 @@ JSON
           }
         }
         before(:each) do
-          stub_request(:put, 'https://api.naver.com/ncc/keywords/nkw-a001-01-000000725744770?fields=bidAmt').
+          stub_request(:put, 'https://api.searchad.naver.com/ncc/keywords/nkw-a001-01-000000725744770?fields=bidAmt').
             to_return(
               status: 200,
               headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -685,7 +685,7 @@ JSON
           }
         }
         before(:each) do
-          stub_request(:put, 'https://api.naver.com/ncc/keywords/nkw-a001-01-000000725744770?fields=links').
+          stub_request(:put, 'https://api.searchad.naver.com/ncc/keywords/nkw-a001-01-000000725744770?fields=links').
             to_return(
               status: 200,
               headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -726,7 +726,7 @@ JSON
           }
         }
         before(:each) do
-          stub_request(:put, 'https://api.naver.com/ncc/keywords/nkw-a001-01-000000725744770?fields=inspect').
+          stub_request(:put, 'https://api.searchad.naver.com/ncc/keywords/nkw-a001-01-000000725744770?fields=inspect').
             to_return(
               status: 200,
               headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -768,7 +768,7 @@ JSON
           }
         }
         before(:each) do
-          stub_request(:put, 'https://api.naver.com/ncc/keywords/nkw-a001-01-000000725744770?fields=').
+          stub_request(:put, 'https://api.searchad.naver.com/ncc/keywords/nkw-a001-01-000000725744770?fields=').
             to_return(
               status: 200,
               headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -834,7 +834,7 @@ JSON
         ]
       }
       before(:each) do
-        stub_request(:put, 'https://api.naver.com/ncc/keywords?fields=userLock').
+        stub_request(:put, 'https://api.searchad.naver.com/ncc/keywords?fields=userLock').
           to_return(
             status: 200,
             headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -904,7 +904,7 @@ JSON
         ]
       }
       before(:each) do
-        stub_request(:put, 'https://api.naver.com/ncc/keywords?fields=').
+        stub_request(:put, 'https://api.searchad.naver.com/ncc/keywords?fields=').
           to_return(
             status: 200,
             headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -980,7 +980,7 @@ JSON
       let(:ad_keyword_id) { 'nkw-a001-01-000000723631063' }
 
       before(:each) do
-        stub_request(:delete, 'https://api.naver.com/ncc/keywords/nkw-a001-01-000000723631063').
+        stub_request(:delete, 'https://api.searchad.naver.com/ncc/keywords/nkw-a001-01-000000723631063').
           to_return(status: 204)
       end
 
@@ -995,7 +995,7 @@ JSON
       let(:ad_keyword_ids) { ['nkw-a001-01-000000725744769', 'nkw-a001-01-000000725744770'] }
 
       before(:each) do
-        stub_request(:delete, 'https://api.naver.com/ncc/keywords?ids=nkw-a001-01-000000725744769,nkw-a001-01-000000725744770').
+        stub_request(:delete, 'https://api.searchad.naver.com/ncc/keywords?ids=nkw-a001-01-000000725744769,nkw-a001-01-000000725744770').
           to_return(status: 204)
       end
 

--- a/spec/naver/searchad/api/ad/service_spec.rb
+++ b/spec/naver/searchad/api/ad/service_spec.rb
@@ -12,7 +12,7 @@ describe Ad::Service do
     context 'when requesting some' do
       let(:ad_ids) { ['nad-a001-01-000000015970482', 'nad-a001-01-000000015970494'] }
       before(:each) do
-        stub_request(:get, 'https://api.naver.com/ncc/ads?ids=nad-a001-01-000000015970482,nad-a001-01-000000015970494').
+        stub_request(:get, 'https://api.searchad.naver.com/ncc/ads?ids=nad-a001-01-000000015970482,nad-a001-01-000000015970494').
           to_return(
             status: 200,
             headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -150,7 +150,7 @@ JSON
     context 'when all ok' do
       let(:adgroup_id) { 'grp-a001-01-000000003865468' }
       before(:each) do
-        stub_request(:get, 'https://api.naver.com/ncc/ads?nccAdgroupId=grp-a001-01-000000003865468').
+        stub_request(:get, 'https://api.searchad.naver.com/ncc/ads?nccAdgroupId=grp-a001-01-000000003865468').
           to_return(
             status: 200,
             headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -288,7 +288,7 @@ JSON
     context 'when all ok' do
       let(:ad_id) { 'nad-a001-01-000000015970482' }
       before(:each) do
-        stub_request(:get, 'https://api.naver.com/ncc/ads/nad-a001-01-000000015970482').
+        stub_request(:get, 'https://api.searchad.naver.com/ncc/ads/nad-a001-01-000000015970482').
           to_return(
             status: 200,
             headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -390,7 +390,7 @@ JSON
         }
       }
       before(:each) do
-        stub_request(:post, 'https://api.naver.com/ncc/ads').
+        stub_request(:post, 'https://api.searchad.naver.com/ncc/ads').
           to_return(
             status: 200,
             headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -483,7 +483,7 @@ JSON
         }
       }
       before(:each) do
-        stub_request(:post, 'https://api.naver.com/ncc/ads').
+        stub_request(:post, 'https://api.searchad.naver.com/ncc/ads').
           to_return(
             status: 200,
             headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -573,7 +573,7 @@ JSON
           }
         }
         before(:each) do
-          stub_request(:put, 'https://api.naver.com/ncc/ads/nad-a001-01-000000015971701?fields=userLock').
+          stub_request(:put, 'https://api.searchad.naver.com/ncc/ads/nad-a001-01-000000015971701?fields=userLock').
             to_return(
               status: 200,
               headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -602,7 +602,7 @@ JSON
           }
         }
         before(:each) do
-          stub_request(:put, 'https://api.naver.com/ncc/ads/nad-a001-01-000000015971701?fields=inspect').
+          stub_request(:put, 'https://api.searchad.naver.com/ncc/ads/nad-a001-01-000000015971701?fields=inspect').
             to_return(
               status: 200,
               headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -633,7 +633,7 @@ JSON
         }
 
         before(:each) do
-          stub_request(:put, 'https://api.naver.com/ncc/ads/nad-a001-01-000000015971701?fields=').
+          stub_request(:put, 'https://api.searchad.naver.com/ncc/ads/nad-a001-01-000000015971701?fields=').
             to_return(
               status: 400,
               body: <<-JSON
@@ -664,7 +664,7 @@ JSON
       let(:ad_id) { 'nad-a001-01-000000015971701' }
 
       before(:each) do
-        stub_request(:delete, 'https://api.naver.com/ncc/ads/nad-a001-01-000000015971701').
+        stub_request(:delete, 'https://api.searchad.naver.com/ncc/ads/nad-a001-01-000000015971701').
           to_return(status: 204)
       end
 
@@ -680,7 +680,7 @@ JSON
       let(:target_ad_group_id) { 'grp-a001-01-000000003864948' }
 
       before(:each) do
-        stub_request(:put, 'https://api.naver.com/ncc/ads?ids=nad-a001-01-000000015970482,nad-a001-01-000000015970494&targetAdgroupId=grp-a001-01-000000003864948&userLock=true').
+        stub_request(:put, 'https://api.searchad.naver.com/ncc/ads?ids=nad-a001-01-000000015970482,nad-a001-01-000000015970494&targetAdgroupId=grp-a001-01-000000003864948&userLock=true').
           to_return(
             status: 200,
             headers: {'Content-Type' => 'application/json;charset=UTF-8'},

--- a/spec/naver/searchad/api/adgroup/service_spec.rb
+++ b/spec/naver/searchad/api/adgroup/service_spec.rb
@@ -12,7 +12,7 @@ describe Adgroup::Service do
     context 'when requesting more than one' do
       include_context 'request is for adgroup list response'
 
-      let(:url) { 'https://api.naver.com/ncc/adgroups' }
+      let(:url) { 'https://api.searchad.naver.com/ncc/adgroups' }
 
       it 'should return an array of relevant adgroup items' do
         expect { |b| this.list_adgroups(&b) }.
@@ -98,7 +98,7 @@ describe Adgroup::Service do
     context 'when requesting more than one' do
       include_context 'request is for adgroup list response'
 
-      let(:url) { "https://api.naver.com/ncc/adgroups?ids=#{adgroup_ids.join(',')}" }
+      let(:url) { "https://api.searchad.naver.com/ncc/adgroups?ids=#{adgroup_ids.join(',')}" }
       let(:adgroup_ids) { %w[grp-a001-01-000000003853231 grp-a001-01-000000003853237] }
 
       it 'should return an array of relevant adgroup items' do
@@ -182,7 +182,7 @@ describe Adgroup::Service do
 
     context 'when requesting none-existing one' do
       before(:each) do
-        stub_request(:get, 'https://api.naver.com/ncc/adgroups?ids=none-existing').
+        stub_request(:get, 'https://api.searchad.naver.com/ncc/adgroups?ids=none-existing').
           to_return(
             status: 404,
             body: <<-JSON
@@ -205,7 +205,7 @@ JSON
     context 'when all ok' do
       include_context 'request is for adgroup list response'
 
-      let(:url) { 'https://api.naver.com/ncc/adgroups?nccCampaignId=cmp-a001-01-000000000652963' }
+      let(:url) { 'https://api.searchad.naver.com/ncc/adgroups?nccCampaignId=cmp-a001-01-000000000652963' }
       let(:campaign_id) { 'cmp-a001-01-000000000652963' }
 
       it 'should return an array of relevant adgroup items' do
@@ -289,7 +289,7 @@ JSON
 
     context 'when requesting none existing id' do
       before(:each) do
-        stub_request(:get, 'https://api.naver.com/ncc/adgroups?nccCampaignId=none-existing').
+        stub_request(:get, 'https://api.searchad.naver.com/ncc/adgroups?nccCampaignId=none-existing').
           to_return(
             status: 404,
             body: <<-JSON
@@ -312,7 +312,7 @@ JSON
     context 'when all ok' do
       include_context 'request is for adgroup list response'
 
-      let(:url) { 'https://api.naver.com/ncc/adgroups?nccLabelId=working_label_id' }
+      let(:url) { 'https://api.searchad.naver.com/ncc/adgroups?nccLabelId=working_label_id' }
       let(:label_id) { 'working_label_id' }
 
       it 'should return an array of relevant adgroup items' do
@@ -396,7 +396,7 @@ JSON
 
     context 'when requesting none existing id' do
       before(:each) do
-        stub_request(:get, 'https://api.naver.com/ncc/adgroups?nccLabelId=none-existing').
+        stub_request(:get, 'https://api.searchad.naver.com/ncc/adgroups?nccLabelId=none-existing').
           to_return(
             status: 404,
             body: <<-JSON
@@ -419,7 +419,7 @@ JSON
     context 'when all ok' do
       include_context 'request is for a single adgroup response'
 
-      let(:url) { 'https://api.naver.com/ncc/adgroups/grp-a001-01-000000003853231' }
+      let(:url) { 'https://api.searchad.naver.com/ncc/adgroups/grp-a001-01-000000003853231' }
       let(:adgroup_id) { 'grp-a001-01-000000003853231' }
 
       it 'should return relevant adgroup item' do
@@ -518,7 +518,7 @@ JSON
 
     context 'when requesting none existing id' do
       before(:each) do
-        stub_request(:get, 'https://api.naver.com/ncc/adgroups/none-existing').
+        stub_request(:get, 'https://api.searchad.naver.com/ncc/adgroups/none-existing').
           to_return(
             status: 404,
             body: <<-JSON
@@ -548,7 +548,7 @@ JSON
         }
       }
       before(:each) do
-        stub_request(:post, 'https://api.naver.com/ncc/adgroups').
+        stub_request(:post, 'https://api.searchad.naver.com/ncc/adgroups').
           to_return(
             status: 200,
             headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -750,7 +750,7 @@ JSON
         }
       }
       before(:each) do
-        stub_request(:post, 'https://api.naver.com/ncc/adgroups').
+        stub_request(:post, 'https://api.searchad.naver.com/ncc/adgroups').
           to_return(
             status: 400,
             body: <<-JSON
@@ -797,7 +797,7 @@ JSON
         }
       }
       before(:each) do
-        stub_request(:post, 'https://api.naver.com/ncc/adgroups').
+        stub_request(:post, 'https://api.searchad.naver.com/ncc/adgroups').
           to_return(
             status: 200,
             headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -1000,7 +1000,7 @@ JSON
           }
         }
         before(:each) do
-          stub_request(:put, 'https://api.naver.com/ncc/adgroups/grp-a001-01-000000003865468?fields=userLock').
+          stub_request(:put, 'https://api.searchad.naver.com/ncc/adgroups/grp-a001-01-000000003865468?fields=userLock').
             to_return(
               status: 200,
               headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -1039,7 +1039,7 @@ JSON
           }
         }
         before(:each) do
-          stub_request(:put, 'https://api.naver.com/ncc/adgroups/grp-a001-01-000000003865468?fields=bidAmt').
+          stub_request(:put, 'https://api.searchad.naver.com/ncc/adgroups/grp-a001-01-000000003865468?fields=bidAmt').
             to_return(
               status: 200,
               headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -1079,7 +1079,7 @@ JSON
           }
         }
         before(:each) do
-          stub_request(:put, 'https://api.naver.com/ncc/adgroups/grp-a001-01-000000003865468?fields=budget').
+          stub_request(:put, 'https://api.searchad.naver.com/ncc/adgroups/grp-a001-01-000000003865468?fields=budget').
             to_return(
               status: 200,
               headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -1120,7 +1120,7 @@ JSON
           }
         }
         before(:each) do
-          stub_request(:put, 'https://api.naver.com/ncc/adgroups/grp-a001-01-000000003865468?fields=useKeywordPlus').
+          stub_request(:put, 'https://api.searchad.naver.com/ncc/adgroups/grp-a001-01-000000003865468?fields=useKeywordPlus').
             to_return(
               status: 200,
               headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -1161,7 +1161,7 @@ JSON
           }
         }
         before(:each) do
-          stub_request(:put, 'https://api.naver.com/ncc/adgroups/grp-a001-01-000000003865468?fields=networkBidWeight').
+          stub_request(:put, 'https://api.searchad.naver.com/ncc/adgroups/grp-a001-01-000000003865468?fields=networkBidWeight').
             to_return(
               status: 200,
               headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -1223,7 +1223,7 @@ JSON
           }
         }
         before(:each) do
-          stub_request(:put, 'https://api.naver.com/ncc/adgroups/grp-a001-01-000000003865468?fields=targetLocation').
+          stub_request(:put, 'https://api.searchad.naver.com/ncc/adgroups/grp-a001-01-000000003865468?fields=targetLocation').
             to_return(
               status: 200,
               headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -1285,7 +1285,7 @@ JSON
           }
         }
         before(:each) do
-          stub_request(:put, 'https://api.naver.com/ncc/adgroups/grp-a001-01-000000003865468?fields=targetTime').
+          stub_request(:put, 'https://api.searchad.naver.com/ncc/adgroups/grp-a001-01-000000003865468?fields=targetTime').
             to_return(
               status: 200,
               headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -1364,7 +1364,7 @@ JSON
         }
 
         before(:each) do
-          stub_request(:put, 'https://api.naver.com/ncc/adgroups/grp-a001-01-000000003865468?fields=targetMedia').
+          stub_request(:put, 'https://api.searchad.naver.com/ncc/adgroups/grp-a001-01-000000003865468?fields=targetMedia').
             to_return(
               status: 200,
               headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -1494,7 +1494,7 @@ JSON
           }
         }
         before(:each) do
-          stub_request(:put, 'https://api.naver.com/ncc/adgroups/grp-a001-01-000000003865468').
+          stub_request(:put, 'https://api.searchad.naver.com/ncc/adgroups/grp-a001-01-000000003865468').
             to_return(
               status: 200,
               headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -1717,7 +1717,7 @@ JSON
       let(:adgroup_id) { 'grp-a001-01-000000003853231' }
 
       before(:each) do
-        stub_request(:delete, 'https://api.naver.com/ncc/adgroups/grp-a001-01-000000003853231').
+        stub_request(:delete, 'https://api.searchad.naver.com/ncc/adgroups/grp-a001-01-000000003853231').
           to_return(status: 204)
       end
 
@@ -1730,7 +1730,7 @@ JSON
       let(:adgroup_id) { 'none-existing' }
 
       before(:each) do
-        stub_request(:delete, 'https://api.naver.com/ncc/adgroups/none-existing').
+        stub_request(:delete, 'https://api.searchad.naver.com/ncc/adgroups/none-existing').
           to_return(
             status: 404,
             body: <<-JSON

--- a/spec/naver/searchad/api/bizmoney/service_spec.rb
+++ b/spec/naver/searchad/api/bizmoney/service_spec.rb
@@ -11,7 +11,7 @@ describe Bizmoney::Service do
   describe '#get_bizmoney' do
     context 'when requesting bizmoney' do
       before(:each) do
-        stub_request(:get, 'https://api.naver.com/billing/bizmoney').
+        stub_request(:get, 'https://api.searchad.naver.com/billing/bizmoney').
           to_return(
             status: 200,
             headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -45,7 +45,7 @@ describe Bizmoney::Service do
         let(:start_date) { Date.parse('2019-03-01') }
 
         before(:each) do
-          stub_request(:get, "https://api.naver.com/billing/bizmoney/cost?searchEndDt=20190302&searchStartDt=20190301").
+          stub_request(:get, "https://api.searchad.naver.com/billing/bizmoney/cost?searchEndDt=20190302&searchStartDt=20190301").
             to_return(
               status: 200,
               headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -105,7 +105,7 @@ describe Bizmoney::Service do
         let(:start_date) { Date.parse('2019-03-01') }
 
         before(:each) do
-          stub_request(:get, "https://api.naver.com/billing/bizmoney/histories/charge?searchEndDt=20190302&searchStartDt=20190301").
+          stub_request(:get, "https://api.searchad.naver.com/billing/bizmoney/histories/charge?searchEndDt=20190302&searchStartDt=20190301").
             to_return(
               status: 200,
               headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -157,7 +157,7 @@ describe Bizmoney::Service do
         let(:start_date) { Date.parse('2019-03-01') }
 
         before(:each) do
-          stub_request(:get, "https://api.naver.com/billing/bizmoney/histories/exhaust?searchEndDt=20190302&searchStartDt=20190301").
+          stub_request(:get, "https://api.searchad.naver.com/billing/bizmoney/histories/exhaust?searchEndDt=20190302&searchStartDt=20190301").
             to_return(
               status: 200,
               headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -217,7 +217,7 @@ describe Bizmoney::Service do
         let(:start_date) { Date.parse('2019-03-01') }
 
         before(:each) do
-          stub_request(:get, "https://api.naver.com/billing/bizmoney/histories/period?searchEndDt=20190302&searchStartDt=20190301").
+          stub_request(:get, "https://api.searchad.naver.com/billing/bizmoney/histories/period?searchEndDt=20190302&searchStartDt=20190301").
             to_return(
               status: 200,
               headers: {'Content-Type' => 'application/json;charset=UTF-8'},

--- a/spec/naver/searchad/api/campaign/service_spec.rb
+++ b/spec/naver/searchad/api/campaign/service_spec.rb
@@ -20,7 +20,7 @@ describe Campaign::Service do
 
     context 'when all ok' do
       before(:each) do
-        stub_request(:post, 'https://api.naver.com/ncc/campaigns').
+        stub_request(:post, 'https://api.searchad.naver.com/ncc/campaigns').
           with(body: "{\"campaignTp\":\"WEB_SITE\",\"name\":\"test-04\",\"customerId\":\"113131\"}").
             to_return(
               status: 200,
@@ -77,7 +77,7 @@ JSON
     context 'when no authorization is given' do
       before(:each) do
         this.authorization = nil
-        stub_request(:post, 'https://api.naver.com/ncc/campaigns').
+        stub_request(:post, 'https://api.searchad.naver.com/ncc/campaigns').
           with(body: "{\"campaignTp\":\"WEB_SITE\",\"name\":\"test-04\",\"customerId\":\"113131\"}").
             to_return(
               status: 403,
@@ -101,7 +101,7 @@ JSON
 
     context 'when invalid api key is given' do
       before(:each) do
-        stub_request(:post, 'https://api.naver.com/ncc/campaigns').
+        stub_request(:post, 'https://api.searchad.naver.com/ncc/campaigns').
           with(body: "{\"campaignTp\":\"WEB_SITE\",\"name\":\"test-04\",\"customerId\":\"113131\"}").
             to_return(
               status: 403,
@@ -125,7 +125,7 @@ JSON
 
     context 'when invalid api secret is given' do
       before(:each) do
-        stub_request(:post, 'https://api.naver.com/ncc/campaigns').
+        stub_request(:post, 'https://api.searchad.naver.com/ncc/campaigns').
           with(body: "{\"campaignTp\":\"WEB_SITE\",\"name\":\"test-04\",\"customerId\":\"113131\"}").
             to_return(
               status: 403,
@@ -149,7 +149,7 @@ JSON
 
     context 'when invalid client id in authorization is given' do
       before(:each) do
-        stub_request(:post, 'https://api.naver.com/ncc/campaigns').
+        stub_request(:post, 'https://api.searchad.naver.com/ncc/campaigns').
           with(body: "{\"campaignTp\":\"WEB_SITE\",\"name\":\"test-04\",\"customerId\":\"113131\"}").
             to_return(
               status: 403,
@@ -175,7 +175,7 @@ JSON
     context 'when creating a campaign with existing name' do
       before(:each) do
         campaign['name'] = 'existing-campaign'
-        stub_request(:post, 'https://api.naver.com/ncc/campaigns').
+        stub_request(:post, 'https://api.searchad.naver.com/ncc/campaigns').
           with(body: "{\"campaignTp\":\"WEB_SITE\",\"name\":\"existing-campaign\",\"customerId\":\"113131\"}").
             to_return(
               status: 400,
@@ -207,7 +207,7 @@ JSON
   describe '#list_campaigns_by_ids' do
     context 'when requesting multiple ids' do
       before(:each) do
-        stub_request(:get, 'https://api.naver.com/ncc/campaigns/?ids=cmp-a001-01-000000000652963,cmp-a001-01-000000000653273').
+        stub_request(:get, 'https://api.searchad.naver.com/ncc/campaigns/?ids=cmp-a001-01-000000000652963,cmp-a001-01-000000000653273').
           to_return(
             status: 200,
             headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -304,7 +304,7 @@ JSON
 
     context 'when requesting none existing id' do
       before(:each) do
-        stub_request(:get, 'https://api.naver.com/ncc/campaigns/?ids=none-existing').
+        stub_request(:get, 'https://api.searchad.naver.com/ncc/campaigns/?ids=none-existing').
           to_return(
             status: 404,
             body: <<-JSON
@@ -326,7 +326,7 @@ JSON
   describe '#list_campaigns' do
     context 'when requesting camapgins' do
       before(:each) do
-        stub_request(:get, 'https://api.naver.com/ncc/campaigns').
+        stub_request(:get, 'https://api.searchad.naver.com/ncc/campaigns').
           to_return(
             status: 200,
             headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -425,7 +425,7 @@ JSON
   describe '#get_campaign' do
     context 'when all ok' do
       before(:each) do
-        stub_request(:get, 'https://api.naver.com/ncc/campaigns/cmp-a001-01-000000000652963').
+        stub_request(:get, 'https://api.searchad.naver.com/ncc/campaigns/cmp-a001-01-000000000652963').
           to_return(
             status: 200,
             headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -481,7 +481,7 @@ JSON
 
     context 'when requesting none-existing campaign' do
       before(:each) do
-        stub_request(:get, 'https://api.naver.com/ncc/campaigns/none-existing').
+        stub_request(:get, 'https://api.searchad.naver.com/ncc/campaigns/none-existing').
           to_return(
             status: 404,
             body: <<-JSON
@@ -511,7 +511,7 @@ JSON
         end
 
         before(:each) do
-          stub_request(:put, 'https://api.naver.com/ncc/campaigns/cmp-a001-01-000000000652963?fields=userLock').
+          stub_request(:put, 'https://api.searchad.naver.com/ncc/campaigns/cmp-a001-01-000000000652963?fields=userLock').
           to_return(
             status: 200,
             headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -540,7 +540,7 @@ JSON
         end
 
         before(:each) do
-          stub_request(:put, 'https://api.naver.com/ncc/campaigns/cmp-a001-01-000000000652963?fields=budget').
+          stub_request(:put, 'https://api.searchad.naver.com/ncc/campaigns/cmp-a001-01-000000000652963?fields=budget').
           to_return(
             status: 200,
             headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -572,7 +572,7 @@ JSON
         end
 
         before(:each) do
-          stub_request(:put, 'https://api.naver.com/ncc/campaigns/cmp-a001-01-000000000652963?fields=period').
+          stub_request(:put, 'https://api.searchad.naver.com/ncc/campaigns/cmp-a001-01-000000000652963?fields=period').
             to_return(
               status: 200,
               headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -613,7 +613,7 @@ JSON
           }
         end
         before(:each) do
-          stub_request(:put, 'https://api.naver.com/ncc/campaigns/cmp-a001-01-000000000652963').
+          stub_request(:put, 'https://api.searchad.naver.com/ncc/campaigns/cmp-a001-01-000000000652963').
             to_return(
               status: 200,
               headers: {'Content-Type' => 'application/json;charset=UTF-8'},
@@ -680,7 +680,7 @@ JSON
       end
 
       before(:each) do
-        stub_request(:put, 'https://api.naver.com/ncc/campaigns/none-existing?fields=userLock').
+        stub_request(:put, 'https://api.searchad.naver.com/ncc/campaigns/none-existing?fields=userLock').
           to_return(
             status: 404,
             body: <<-JSON
@@ -708,7 +708,7 @@ JSON
       end
 
       before(:each) do
-        stub_request(:put, 'https://api.naver.com/ncc/campaigns/cmp-a001-01-000000000652963?fields=deliveryMethod').
+        stub_request(:put, 'https://api.searchad.naver.com/ncc/campaigns/cmp-a001-01-000000000652963?fields=deliveryMethod').
           to_return(
             status: 400,
             body: <<-JSON
@@ -733,7 +733,7 @@ JSON
       let(:campaign_id) { 'cmp-a001-01-000000000653279' }
 
       before(:each) do
-        stub_request(:delete, 'https://api.naver.com/ncc/campaigns/cmp-a001-01-000000000653279').
+        stub_request(:delete, 'https://api.searchad.naver.com/ncc/campaigns/cmp-a001-01-000000000653279').
           to_return(status: 204)
       end
 
@@ -747,7 +747,7 @@ JSON
       let(:campaign_id) { 'none-existing' }
 
       before(:each) do
-        stub_request(:delete, 'https://api.naver.com/ncc/campaigns/none-existing').
+        stub_request(:delete, 'https://api.searchad.naver.com/ncc/campaigns/none-existing').
           to_return(
             status: 404,
             body: <<-JSON


### PR DESCRIPTION
Updates the domain from **api.naver.com** to **api.searchad.naver.com**

Discontinuation of api.naver.com domain service: March 22, 2023