### PR TITLE
fix/remove_slash_from_stat-report_paths

### DIFF
--- a/lib/naver/searchad/api/stat-report/service.rb
+++ b/lib/naver/searchad/api/stat-report/service.rb
@@ -21,18 +21,18 @@ module Naver
           end
 
           def get_stat_report(report_job_id, options: {}, &block)
-            command = make_command(:get, '/stat-reports/{report_job_id}', options)
+            command = make_command(:get, 'stat-reports/{report_job_id}', options)
             command.params['report_job_id'] = report_job_id
             execute_command(command, &block)
           end
 
           def list_stat_reports(options: {}, &block)
-            command = make_command(:get, '/stat-reports', options)
+            command = make_command(:get, 'stat-reports', options)
             execute_command(command, &block)
           end
 
           def create_stat_report(type, date, options: {}, &block)
-            command = make_command(:post, '/stat-reports', options)
+            command = make_command(:post, 'stat-reports', options)
             command.request_object = {
               'reportTp' => type,
               'statDt' => date
@@ -41,12 +41,12 @@ module Naver
           end
 
           def delete_stat_reports(options: {}, &block)
-            command = make_command(:delete, '/stat-reports', options)
+            command = make_command(:delete, 'stat-reports', options)
             execute_command(command, &block)
           end
 
           def delete_stat_report(report_job_id, options: {}, &block)
-            command = make_command(:delete, '/stat-reports/{report_job_id}', options)
+            command = make_command(:delete, 'stat-reports/{report_job_id}', options)
             command.params['report_job_id'] = report_job_id
             execute_command(command, &block)
           end

--- a/lib/naver/searchad/api/version.rb
+++ b/lib/naver/searchad/api/version.rb
@@ -1,7 +1,7 @@
 module Naver
   module Searchad
     module Api
-      VERSION = '1.1.0'
+      VERSION = '1.1.1'
 
       OS_VERSION = begin
         if RUBY_PLATFORM =~ /mswin|win32|mingw|bccwin|cygwin/


### PR DESCRIPTION
Removes the beginning slash from all **stat-report** paths as this causes two slashes to be added when the full URL is generated here: https://github.com/forward3d/naver-searchad-api/blob/eb3ce398900213c6d0b43cb97925dd4b29d5aa33/lib/naver/searchad/api/core/base_service.rb#L45

In turn, this causes the new Naver domain to reject the paths.